### PR TITLE
reconcile: parallel --setup wizard merge + close H-1/H-2 secret leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **feat(wizard):** First-run interactive setup wizard. Running bare `az-ai`
+  on an interactive terminal with no credentials configured now launches a
+  guided setup that prompts for the Azure OpenAI endpoint, API key (masked
+  input), and default model deployment, then persists them to
+  `~/.azureopenai-cli.json` (0600 perms). Re-run any time with `az-ai --setup`
+  (alias `--init-wizard`). `UserConfig` gained `endpoint` and `api_key`
+  fields that serve as fallbacks when the matching environment variables
+  are unset; `api_key` is redacted (`api_key=<redacted>`) in
+  `az-ai --config list` output. The wizard is suppressed under `--raw`,
+  `--json`, or when stdin/stdout is redirected so scripted and piped
+  callers continue to see the existing env-var error.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+- Fail closed when masked input is unavailable: `SetupWizard.ReadMaskedLine`
+  no longer falls back to unmasked `Console.ReadLine` when `Console.ReadKey`
+  throws on pseudo-TTYs (some container runtimes, `dotnet test` capture, CI
+  runners with `tty: true` but no `/dev/tty`, restricted hosts, WSL +
+  `ssh -t` edge cases). The fallback echoed every keystroke of the API key
+  to scrollback / tmux logs / TTY loggers. The wizard now emits a one-line
+  `[ERROR]` warning to stderr and short-circuits to exit 130 without ever
+  accepting plaintext input. Newman audit H-1.
+- Refuse `az-ai --config get api_key` to prevent secret leakage via
+  scrollback, shell history of pipe targets, screen-share, and terminal
+  logs. The get-by-name path was an escape hatch around the `--config list`
+  redaction. Users should re-run `az-ai --setup` or read
+  `~/.azureopenai-cli.json` directly (file is mode 0600). `UserConfig.GetKey`
+  itself still returns the raw value for in-process callers (e.g. the
+  wizard); the refusal lives at the print site only. Newman audit H-2.
 
 ## [2.1.1] -- 2026-04-24
 

--- a/azureopenai-cli/Program.cs
+++ b/azureopenai-cli/Program.cs
@@ -1971,6 +1971,22 @@ complete -c az-ai -w az-ai
                 {
                     return ErrorAndExit("--config get requires <key>", 1, opts.Json);
                 }
+                // Newman audit H-2: never print the raw API key to stdout.
+                // Even though ListKeys redacts, the get-by-name path was an
+                // escape hatch that leaks via scrollback, shell history of
+                // pipe targets, screen-share, and terminal logs. Refuse with
+                // a helpful message; users can re-run --setup or read the
+                // 0600 config file directly.
+                if (string.Equals(opts.ConfigKey, "api_key", StringComparison.Ordinal))
+                {
+                    return ErrorAndExit(
+                        "Refusing to print api_key to stdout (would leak via scrollback, "
+                        + "shell history, and pipe targets). "
+                        + "To inspect: cat ~/.azureopenai-cli.json (file is mode 0600). "
+                        + "To re-set:  az-ai --setup",
+                        1,
+                        opts.Json);
+                }
                 var value = config.GetKey(opts.ConfigKey);
                 if (value == null)
                 {

--- a/azureopenai-cli/Program.cs
+++ b/azureopenai-cli/Program.cs
@@ -1979,10 +1979,11 @@ complete -c az-ai -w az-ai
                 // 0600 config file directly.
                 if (string.Equals(opts.ConfigKey, "api_key", StringComparison.Ordinal))
                 {
+                    var configPath = config.LoadedFrom ?? UserConfig.DefaultPath;
                     return ErrorAndExit(
                         "Refusing to print api_key to stdout (would leak via scrollback, "
                         + "shell history, and pipe targets). "
-                        + "To inspect: cat ~/.azureopenai-cli.json (file is mode 0600). "
+                        + $"To inspect: {configPath} (file is mode 0600). "
                         + "To re-set:  az-ai --setup",
                         1,
                         opts.Json);

--- a/azureopenai-cli/Program.cs
+++ b/azureopenai-cli/Program.cs
@@ -1959,7 +1959,7 @@ complete -c az-ai -w az-ai
                 if (!config.SetKey(opts.ConfigKey, opts.ConfigValue))
                 {
                     return ErrorAndExit(
-                        $"Unknown config key '{opts.ConfigKey}'. Supported: default_model, models.<alias>, defaults.<temperature|max_tokens|timeout_seconds|system_prompt>",
+                        $"Unknown config key '{opts.ConfigKey}'. Supported: endpoint, api_key, default_model, models.<alias>, defaults.<temperature|max_tokens|timeout_seconds|system_prompt>",
                         1, opts.Json);
                 }
                 config.Save();

--- a/azureopenai-cli/Program.cs
+++ b/azureopenai-cli/Program.cs
@@ -181,8 +181,26 @@ internal class Program
         // --setup / "setup": interactive configuration wizard. Runs before
         // credential resolution so it works even when env vars are missing
         // or the endpoint is unreachable — that's the whole point.
+        //
+        // Hard gates (Newman/Puddy invariants from the parallel stash impl):
+        //   * Refuse under --raw / --json: machine surfaces must never block
+        //     on an interactive prompt.
+        //   * Refuse when stdin or stdout is redirected: pipes / CI / scripts
+        //     get a clean error, not a hung process.
         if (opts.Setup)
         {
+            if (opts.Raw || opts.Json)
+            {
+                return ErrorAndExit(
+                    "--setup cannot be combined with --raw or --json (interactive only)",
+                    1, jsonMode: opts.Json);
+            }
+            if (!SetupWizard.IsInteractiveTty())
+            {
+                return ErrorAndExit(
+                    "--setup requires an interactive terminal (stdin/stdout must not be redirected)",
+                    1, jsonMode: opts.Json);
+            }
             return await SetupWizard.RunAsync();
         }
 
@@ -1037,6 +1055,7 @@ internal class Program
                     else { Fail("--cache-ttl requires a positive integer (hours)"); }
                     break;
                 case "--setup":
+                case "--init-wizard":
                     setup = true;
                     break;
                 default:

--- a/azureopenai-cli/Program.cs
+++ b/azureopenai-cli/Program.cs
@@ -303,9 +303,27 @@ internal class Program
             return RunEstimate(opts);
         }
 
-        // Resolve endpoint and API key from env
+        // Resolve endpoint and API key. Precedence: env > UserConfig (set via the
+        // setup wizard or `--config set`) > error/auto-wizard. Environment variables
+        // win so a project-local .env / shell export always overrides the persisted
+        // user config (matches FR-003/FR-009 documented precedence).
         var endpoint = Environment.GetEnvironmentVariable("AZUREOPENAIENDPOINT");
+        if (string.IsNullOrWhiteSpace(endpoint)) endpoint = userConfig.Endpoint;
+
         var apiKey = Environment.GetEnvironmentVariable("AZUREOPENAIAPI");
+        if (string.IsNullOrWhiteSpace(apiKey)) apiKey = userConfig.ApiKey;
+
+        // First-run wizard auto-trigger: credentials are missing, the user did
+        // not give us a prompt or task file, stdin is a TTY, and no machine-
+        // readable output flags are set. Walk them through setup instead of
+        // dumping a terse env-var error. Explicit --setup above takes precedence;
+        // this block only fires when the user simply ran bare `az-ai` with
+        // nothing configured yet. (CHANGELOG claim, restored from stash impl.)
+        if (ShouldAutoLaunchSetup(opts, endpoint, apiKey,
+                SetupWizard.IsInteractiveTty(), Console.IsInputRedirected))
+        {
+            return await SetupWizard.RunAsync();
+        }
 
         if (string.IsNullOrWhiteSpace(endpoint))
         {
@@ -768,6 +786,42 @@ internal class Program
     /// Parse errors set <c>ParseError=true</c> and <c>ShowHelp=true</c>; they do
     /// not throw. Caller is expected to check <c>ParseError</c> and exit(1).
     /// </summary>
+    /// <summary>
+    /// First-run wizard auto-trigger predicate. Returns true when the user
+    /// invoked bare <c>az-ai</c> with no usable credentials on an interactive
+    /// terminal and no machine-readable output flags. Extracted as a pure
+    /// function (no Console / env reads) so the decision is unit-testable
+    /// without a PTY harness — the caller passes in the terminal facts.
+    ///
+    /// Gates (must ALL hold to auto-launch):
+    ///   * Credentials missing: endpoint OR apiKey is null/whitespace.
+    ///   * No prompt: <c>opts.Prompt</c> and <c>opts.TaskFile</c> are empty.
+    ///   * Stdin is not redirected (no pipe / heredoc feeding us).
+    ///   * Stdin and stdout are both TTYs (<c>isInteractiveTty</c>).
+    ///   * Neither <c>--raw</c> nor <c>--json</c> is set.
+    ///
+    /// Explicit <c>--setup</c> / <c>--init-wizard</c> handling earlier in
+    /// <c>RunAsync</c> takes precedence; this only fires for bare invocations.
+    /// </summary>
+    internal static bool ShouldAutoLaunchSetup(
+        CliOptions opts,
+        string? endpoint,
+        string? apiKey,
+        bool isInteractiveTty,
+        bool stdinRedirected)
+    {
+        bool credsMissing = string.IsNullOrWhiteSpace(endpoint)
+            || string.IsNullOrWhiteSpace(apiKey);
+        bool noPromptOrPipe = string.IsNullOrWhiteSpace(opts.Prompt)
+            && string.IsNullOrWhiteSpace(opts.TaskFile)
+            && !stdinRedirected;
+        return credsMissing
+            && noPromptOrPipe
+            && !opts.Raw
+            && !opts.Json
+            && isInteractiveTty;
+    }
+
     internal static CliOptions ParseArgs(string[] args)
     {
         string? model = null;
@@ -1630,6 +1684,7 @@ Configuration (FR-003/FR-009, precedence: env > CLI > ./.azureopenai-cli.json > 
 Setup:
   --setup                   Interactive guided configuration wizard
                             (works even when endpoint/credentials are broken)
+  --init-wizard             Alias for --setup
 
 Shell Completions:
   --completions <shell>     Emit bash|zsh|fish completion script to stdout
@@ -1705,7 +1760,7 @@ _az_ai_completions()
     COMPREPLY=()
     cur=""${COMP_WORDS[COMP_CWORD]}""
     prev=""${COMP_WORDS[COMP_CWORD-1]}""
-    opts=""--agent --ralph --persona --personas --squad-init --raw --json --version --help --model --set-model --current-model --models --list-models --completions --temperature --max-tokens --timeout --system --schema --tools --max-rounds --max-iterations --config --short --estimate --estimate-with-output --telemetry --otel --metrics --validate --task-file --cache --cache-ttl --setup""
+    opts=""--agent --ralph --persona --personas --squad-init --raw --json --version --help --model --set-model --current-model --models --list-models --completions --temperature --max-tokens --timeout --system --schema --tools --max-rounds --max-iterations --config --short --estimate --estimate-with-output --telemetry --otel --metrics --validate --task-file --cache --cache-ttl --setup --init-wizard""
 
     case ""${prev}"" in
         --completions)
@@ -1767,6 +1822,7 @@ _az-ai() {
         '--validate[Ralph validator]:cmd:'
         '--task-file[Ralph task file]:path:'
         '--setup[Interactive setup wizard]'
+        '--init-wizard[Alias for --setup]'
     )
     _arguments -s $opts
 }
@@ -1806,6 +1862,7 @@ complete -c az-ai -l metrics -d 'Enable OTLP metrics'
 complete -c az-ai -l validate -d 'Ralph validator' -r
 complete -c az-ai -l task-file -d 'Ralph task file' -r
 complete -c az-ai -l setup -d 'Interactive setup wizard'
+complete -c az-ai -l init-wizard -d 'Alias for --setup'
 complete -c az-ai -w az-ai
 ";
 

--- a/azureopenai-cli/SetupWizard.cs
+++ b/azureopenai-cli/SetupWizard.cs
@@ -1,170 +1,280 @@
-using System.Net;
-using System.Text.Json;
+using System.Text;
 
 namespace AzureOpenAI_CLI;
 
 /// <summary>
-/// Interactive setup wizard (<c>--setup</c> / <c>az-ai setup</c>).
-/// Guides the user through endpoint, API key, and model configuration.
-/// Runs before credential resolution so it works even when the current
-/// config is broken — that's the whole point.
+/// Interactive setup wizard (<c>--setup</c> / <c>--init-wizard</c> /
+/// <c>az-ai setup</c>). Walks the user through configuring the Azure OpenAI
+/// endpoint, API key, and a default model deployment, then persists the
+/// values to <c>~/.azureopenai-cli.json</c> (0600 perms via
+/// <see cref="UserConfig.Save"/>).
+///
+/// <para>
+/// Invariants:
+/// <list type="bullet">
+///   <item>Never runs when stdin or stdout is redirected — interactive
+///   prompts must never block a pipe / CI / script. The caller in
+///   <see cref="Program"/> gates on <see cref="IsInteractiveTty"/> before
+///   invoking <see cref="RunAsync"/>; the wizard re-checks defensively.</item>
+///   <item>Never runs under <c>--raw</c> / <c>--json</c> (also gated by the
+///   caller).</item>
+///   <item>The API key is read character-by-character with <c>*</c> echoed
+///   in place of each char; it is never printed to stdout or stderr in
+///   plaintext.</item>
+///   <item>Ctrl+C / Esc / EOF aborts with exit 130 and no partial writes —
+///   <see cref="UserConfig.Save"/> is only called once every prompt has
+///   succeeded.</item>
+/// </list>
+/// </para>
 /// </summary>
 internal static class SetupWizard
 {
+    /// <summary>
+    /// Exit code for user-initiated cancellation (Ctrl+C / SIGINT / Esc / EOF).
+    /// Matches the convention used elsewhere in <see cref="Program"/>.
+    /// </summary>
+    private const int ExitCanceled = 130;
+
+    /// <summary>
+    /// Run the wizard interactively. Returns a process exit code:
+    /// 0 on success, 130 on user cancellation, 1 on validation failure.
+    /// Persists via <see cref="UserConfig.Save"/> only after every prompt
+    /// has succeeded — partial writes are not possible.
+    /// </summary>
     internal static async Task<int> RunAsync()
     {
-        Console.WriteLine("╭──────────────────────────────────────────────╮");
-        Console.WriteLine("│  az-ai setup wizard                         │");
-        Console.WriteLine("╰──────────────────────────────────────────────╯");
-        Console.WriteLine();
-
-        // ── Step 1: Endpoint ──────────────────────────────────────────
-        var currentEndpoint = Environment.GetEnvironmentVariable("AZUREOPENAIENDPOINT");
-        if (!string.IsNullOrWhiteSpace(currentEndpoint))
-            Console.WriteLine($"  Current endpoint: {currentEndpoint}");
-
-        Console.Write("  Azure OpenAI endpoint URL (https://...): ");
-        var endpoint = Console.ReadLine()?.Trim();
-        if (string.IsNullOrWhiteSpace(endpoint))
+        // Defensive re-check: caller (Program.RunAsync) already gates on this,
+        // but the wizard never trusts the caller for a security invariant.
+        if (!IsInteractiveTty())
         {
-            if (!string.IsNullOrWhiteSpace(currentEndpoint))
-            {
-                endpoint = currentEndpoint;
-                Console.WriteLine($"  (keeping current: {endpoint})");
-            }
-            else
-            {
-                Console.Error.WriteLine("[ERROR] Endpoint is required.");
-                return 1;
-            }
-        }
-
-        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var endpointUri)
-            || endpointUri.Scheme != "https")
-        {
-            Console.Error.WriteLine($"[ERROR] Invalid endpoint: '{endpoint}'. Must be a valid HTTPS URL.");
+            Console.Error.WriteLine(
+                "[ERROR] Setup wizard requires an interactive terminal (stdin/stdout must not be redirected).");
             return 1;
         }
 
-        // ── Step 2: API Key ───────────────────────────────────────────
-        var currentKey = Environment.GetEnvironmentVariable("AZUREOPENAIAPI");
-        var hasCurrentKey = !string.IsNullOrWhiteSpace(currentKey);
-        if (hasCurrentKey)
-            Console.WriteLine($"  Current API key: {currentKey![..4]}...{currentKey[^4..]}");
+        // Touch await so the async signature stays meaningful and forward-
+        // compatible with future async prompts (connectivity check, etc.).
+        await Task.Yield();
 
-        Console.Write("  API key (paste, or press Enter to keep current): ");
-        var apiKey = Console.ReadLine()?.Trim();
-        if (string.IsNullOrWhiteSpace(apiKey))
+        try
         {
-            if (hasCurrentKey)
-            {
-                apiKey = currentKey;
-                Console.WriteLine("  (keeping current key)");
-            }
-            else
-            {
-                Console.Error.WriteLine("[ERROR] API key is required.");
-                return 1;
-            }
-        }
+            PrintBanner();
 
-        // ── Step 3: Connectivity test ─────────────────────────────────
-        Console.Write("  Testing connectivity... ");
-        var reachable = await TestConnectivityAsync(endpointUri);
-        if (reachable)
-        {
-            Console.WriteLine("OK");
-        }
-        else
-        {
-            Console.WriteLine("FAILED");
-            Console.Error.WriteLine($"  [WARNING] Could not reach {endpointUri.Host}. The endpoint may be wrong or temporarily down.");
-            Console.Write("  Continue anyway? [y/N]: ");
-            var cont = Console.ReadLine()?.Trim();
-            if (!string.Equals(cont, "y", StringComparison.OrdinalIgnoreCase))
-            {
-                Console.WriteLine("  Setup cancelled.");
-                return 1;
-            }
-        }
+            var config = UserConfig.Load(quiet: true);
 
-        // ── Step 4: Model deployment ──────────────────────────────────
-        var currentModel = Environment.GetEnvironmentVariable("AZUREOPENAIMODEL");
-        if (!string.IsNullOrWhiteSpace(currentModel))
-            Console.WriteLine($"  Current model: {currentModel}");
+            var endpoint = PromptEndpoint(config.Endpoint);
+            if (endpoint is null) return ExitCanceled;
 
-        Console.Write("  Default model deployment name (e.g. gpt-4o-mini): ");
-        var model = Console.ReadLine()?.Trim();
-        if (string.IsNullOrWhiteSpace(model))
-        {
-            model = currentModel ?? "gpt-4o-mini";
-            Console.WriteLine($"  (using: {model})");
-        }
+            var apiKey = PromptApiKey(hasExisting: !string.IsNullOrEmpty(config.ApiKey));
+            if (apiKey is null) return ExitCanceled;
 
-        // ── Step 5: Model alias ───────────────────────────────────────
-        Console.Write("  Alias for this model (e.g. 'fast', or press Enter to skip): ");
-        var alias = Console.ReadLine()?.Trim();
+            var (alias, deployment) = PromptDefaultModel(config);
+            if (alias is null || deployment is null) return ExitCanceled;
 
-        // ── Step 6: Save config ───────────────────────────────────────
-        var config = UserConfig.Load(quiet: true);
-        if (!string.IsNullOrWhiteSpace(alias))
-        {
-            config.Models[alias] = model;
+            // All prompts succeeded — only now do we mutate + persist. No
+            // partial writes can leak from an aborted wizard.
+            config.Endpoint = endpoint;
+            // Empty string from PromptApiKey signals "keep existing" — only
+            // overwrite when the user actually typed a new key.
+            if (apiKey.Length > 0) config.ApiKey = apiKey;
+            config.Models[alias] = deployment;
             config.DefaultModel = alias;
+
+            config.Save();
+
+            PrintSuccess(config.LoadedFrom ?? UserConfig.DefaultPath);
+            return 0;
         }
-        else
+        catch (OperationCanceledException)
         {
-            config.DefaultModel = model;
+            Console.WriteLine();
+            Console.WriteLine("Setup canceled. No changes saved.");
+            return ExitCanceled;
         }
-        config.Save();
-        Console.WriteLine($"  Config saved to {config.LoadedFrom ?? UserConfig.DefaultPath}");
-
-        // ── Step 7: Write .env file ───────────────────────────────────
-        Console.Write("  Write a .env file in the current directory? [Y/n]: ");
-        var writeEnv = Console.ReadLine()?.Trim();
-        if (string.IsNullOrWhiteSpace(writeEnv)
-            || string.Equals(writeEnv, "y", StringComparison.OrdinalIgnoreCase))
-        {
-            var envPath = Path.Combine(Directory.GetCurrentDirectory(), ".env");
-            var lines = new List<string>
-            {
-                $"AZUREOPENAIENDPOINT={endpoint}",
-                $"AZUREOPENAIAPI={apiKey}",
-                $"AZUREOPENAIMODEL={model}",
-            };
-            File.WriteAllLines(envPath, lines);
-            Console.WriteLine($"  .env written to {envPath}");
-        }
-
-        // ── Step 8: Print shell exports ───────────────────────────────
-        Console.WriteLine();
-        Console.WriteLine("  Add these to your shell profile (~/.bashrc, ~/.zshrc, etc.):");
-        Console.WriteLine();
-        Console.WriteLine($"    export AZUREOPENAIENDPOINT=\"{endpoint}\"");
-        Console.WriteLine($"    export AZUREOPENAIAPI=\"{apiKey}\"");
-        Console.WriteLine($"    export AZUREOPENAIMODEL=\"{model}\"");
-        Console.WriteLine();
-        Console.WriteLine("  Setup complete. Try: az-ai \"Hello, world!\"");
-
-        return 0;
     }
 
     /// <summary>
-    /// Quick connectivity test — HEAD request to the endpoint root.
-    /// Returns true if we get any HTTP response (even 4xx); false on DNS/TCP failure.
+    /// True when the wizard is safe to launch: both stdin and stdout are
+    /// interactive TTYs. Guards against triggering the wizard in scripts,
+    /// pipes, CI, or under <c>--raw</c> / <c>--json</c> consumers.
     /// </summary>
-    private static async Task<bool> TestConnectivityAsync(Uri endpoint)
+    internal static bool IsInteractiveTty()
     {
+        if (Console.IsInputRedirected) return false;
+        if (Console.IsOutputRedirected) return false;
+        return true;
+    }
+
+    private static void PrintBanner()
+    {
+        Console.WriteLine();
+        Console.WriteLine("Welcome to az-ai setup!");
+        Console.WriteLine("This wizard will configure your Azure OpenAI credentials and save");
+        Console.WriteLine($"them to {UserConfig.DefaultPath} (permissions 0600).");
+        Console.WriteLine();
+        Console.WriteLine("Press Ctrl+C at any time to abort without saving.");
+        Console.WriteLine();
+    }
+
+    private static string? PromptEndpoint(string? existing)
+    {
+        // Env var fallback is informational only — we still write to UserConfig.
+        if (string.IsNullOrEmpty(existing))
+            existing = Environment.GetEnvironmentVariable("AZUREOPENAIENDPOINT");
+
+        while (true)
+        {
+            var suffix = string.IsNullOrEmpty(existing) ? "" : $" [{existing}]";
+            Console.Write($"Azure OpenAI endpoint URL{suffix}: ");
+            var input = Console.ReadLine();
+            if (input is null) return null; // EOF / Ctrl+D
+
+            input = input.Trim();
+            if (string.IsNullOrEmpty(input) && !string.IsNullOrEmpty(existing))
+                input = existing;
+
+            if (string.IsNullOrEmpty(input))
+            {
+                Console.WriteLine("  Endpoint is required (e.g. https://my-resource.openai.azure.com).");
+                continue;
+            }
+
+            if (!input.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine("  Endpoint must start with https://");
+                continue;
+            }
+
+            if (!Uri.TryCreate(input, UriKind.Absolute, out _))
+            {
+                Console.WriteLine("  That doesn't look like a valid URL. Try again.");
+                continue;
+            }
+
+            return input.TrimEnd('/');
+        }
+    }
+
+    private static string? PromptApiKey(bool hasExisting)
+    {
+        while (true)
+        {
+            var suffix = hasExisting ? " [press Enter to keep existing]" : "";
+            Console.Write($"Azure OpenAI API key (input hidden){suffix}: ");
+            var key = ReadMaskedLine();
+            Console.WriteLine();
+
+            if (key is null) return null; // Esc / EOF
+
+            if (key.Length == 0)
+            {
+                if (hasExisting)
+                {
+                    // Empty result = "keep existing". Caller (RunAsync)
+                    // interprets length==0 as no overwrite.
+                    return string.Empty;
+                }
+                Console.WriteLine("  API key is required.");
+                continue;
+            }
+
+            if (key.Length < 16)
+            {
+                Console.WriteLine("  That key looks too short — Azure OpenAI keys are typically 32+ chars. Try again.");
+                continue;
+            }
+
+            return key;
+        }
+    }
+
+    private static (string? alias, string? deployment) PromptDefaultModel(UserConfig config)
+    {
+        var existingDeployment = !string.IsNullOrEmpty(config.DefaultModel)
+            && config.Models.TryGetValue(config.DefaultModel, out var ed)
+                ? ed
+                : null;
+        var defaultValue = existingDeployment ?? "gpt-4o-mini";
+
+        Console.Write($"Default model deployment name [{defaultValue}]: ");
+        var input = Console.ReadLine();
+        if (input is null) return (null, null);
+
+        input = input.Trim();
+        if (string.IsNullOrEmpty(input))
+            input = defaultValue;
+
+        // Reuse the existing alias if the user already had one configured;
+        // otherwise default to "default" for predictability.
+        var alias = !string.IsNullOrEmpty(config.DefaultModel)
+            ? config.DefaultModel
+            : "default";
+
+        return (alias, input);
+    }
+
+    private static void PrintSuccess(string path)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Configuration saved to {path}");
+        Console.WriteLine();
+        Console.WriteLine("You're all set. Try:");
+        Console.WriteLine("  az-ai \"Hello, world\"");
+        Console.WriteLine();
+        Console.WriteLine("Re-run this wizard any time with: az-ai --setup");
+        Console.WriteLine("Edit individual keys with:        az-ai --config set <key>=<value>");
+        Console.WriteLine();
+    }
+
+    /// <summary>
+    /// Read a line from stdin with each character echoed as <c>*</c>. Returns
+    /// the entered string (possibly empty) on Enter, or null on Esc / EOF /
+    /// console-not-a-tty fallback failure. Supports Backspace. Never echoes
+    /// the actual key material to any output stream.
+    /// </summary>
+    private static string? ReadMaskedLine()
+    {
+        // Caller already gated on IsInteractiveTty(); ReadKey should be safe.
+        // Defensive try/catch handles exotic hosts (e.g. some CI containers
+        // claim a TTY but throw on ReadKey).
         try
         {
-            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
-            var request = new HttpRequestMessage(HttpMethod.Head, endpoint);
-            var response = await http.SendAsync(request);
-            return true; // Any HTTP response = endpoint is reachable
+            var buffer = new StringBuilder();
+            while (true)
+            {
+                var keyInfo = Console.ReadKey(intercept: true);
+                if (keyInfo.Key == ConsoleKey.Enter)
+                {
+                    return buffer.ToString();
+                }
+                if (keyInfo.Key == ConsoleKey.Backspace)
+                {
+                    if (buffer.Length > 0)
+                    {
+                        buffer.Length -= 1;
+                        Console.Write("\b \b");
+                    }
+                    continue;
+                }
+                if (keyInfo.Key == ConsoleKey.Escape)
+                {
+                    // Esc = cancel, exit-130 path.
+                    return null;
+                }
+                // Ignore control chars (Tab, arrows, F-keys, etc.).
+                if (keyInfo.KeyChar == '\0' || char.IsControl(keyInfo.KeyChar))
+                    continue;
+
+                buffer.Append(keyInfo.KeyChar);
+                Console.Write('*');
+            }
         }
-        catch
+        catch (InvalidOperationException)
         {
-            return false;
+            // Console.ReadKey throws when stdin is redirected. Caller gates
+            // on that; this is purely defensive. Fall back to plain ReadLine
+            // so the wizard still completes (no masking, but won't crash).
+            return Console.ReadLine();
         }
     }
 }

--- a/azureopenai-cli/SetupWizard.cs
+++ b/azureopenai-cli/SetupWizard.cs
@@ -139,20 +139,51 @@ internal static class SetupWizard
                 continue;
             }
 
-            if (!input.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            if (!TryParseEndpointUrl(input, out var rejection))
             {
-                Console.WriteLine("  Endpoint must start with https://");
-                continue;
-            }
-
-            if (!Uri.TryCreate(input, UriKind.Absolute, out _))
-            {
-                Console.WriteLine("  That doesn't look like a valid URL. Try again.");
+                Console.WriteLine($"  {rejection}");
                 continue;
             }
 
             return input.TrimEnd('/');
         }
+    }
+
+    /// <summary>
+    /// Validates that <paramref name="url"/> is a well-formed Azure OpenAI resource root URL:
+    /// must start with <c>https://</c>, parse as an absolute URI, and have no path, query, or fragment.
+    /// Returns <see langword="true"/> when valid; otherwise <see langword="false"/> with a
+    /// human-readable rejection reason in <paramref name="rejection"/>.
+    /// </summary>
+    internal static bool TryParseEndpointUrl(string url, out string? rejection)
+    {
+        if (!url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            rejection = "Endpoint must start with https://";
+            return false;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            rejection = "That doesn't look like a valid URL. Try again.";
+            return false;
+        }
+
+        // Reject deep paths, query strings, and fragments — the endpoint
+        // must be the Azure OpenAI resource root. Anything deeper will
+        // silently break the client SDK's URL construction at runtime.
+        if ((uri.AbsolutePath is not ("" or "/")) ||
+            !string.IsNullOrEmpty(uri.Query) ||
+            !string.IsNullOrEmpty(uri.Fragment))
+        {
+            rejection =
+                "Endpoint must be a root URL with no path, query, or fragment "
+                + "(e.g. https://my-resource.openai.azure.com).";
+            return false;
+        }
+
+        rejection = null;
+        return true;
     }
 
     private static string? PromptApiKey(bool hasExisting)

--- a/azureopenai-cli/SetupWizard.cs
+++ b/azureopenai-cli/SetupWizard.cs
@@ -172,7 +172,7 @@ internal static class SetupWizard
         // Reject deep paths, query strings, and fragments — the endpoint
         // must be the Azure OpenAI resource root. Anything deeper will
         // silently break the client SDK's URL construction at runtime.
-        if ((uri.AbsolutePath is not ("" or "/")) ||
+        if (uri.AbsolutePath != "/" ||
             !string.IsNullOrEmpty(uri.Query) ||
             !string.IsNullOrEmpty(uri.Fragment))
         {

--- a/azureopenai-cli/SetupWizard.cs
+++ b/azureopenai-cli/SetupWizard.cs
@@ -6,8 +6,8 @@ namespace AzureOpenAI_CLI;
 /// Interactive setup wizard (<c>--setup</c> / <c>--init-wizard</c> /
 /// <c>az-ai setup</c>). Walks the user through configuring the Azure OpenAI
 /// endpoint, API key, and a default model deployment, then persists the
-/// values to <c>~/.azureopenai-cli.json</c> (0600 perms via
-/// <see cref="UserConfig.Save"/>).
+/// values to the user config file at <see cref="UserConfig.DefaultPath"/>
+/// (0600 perms via <see cref="UserConfig.Save"/>).
 ///
 /// <para>
 /// Invariants:

--- a/azureopenai-cli/SetupWizard.cs
+++ b/azureopenai-cli/SetupWizard.cs
@@ -271,10 +271,20 @@ internal static class SetupWizard
         }
         catch (InvalidOperationException)
         {
-            // Console.ReadKey throws when stdin is redirected. Caller gates
-            // on that; this is purely defensive. Fall back to plain ReadLine
-            // so the wizard still completes (no masking, but won't crash).
-            return Console.ReadLine();
+            // Console.ReadKey throws on pseudo-TTYs that pass the redirect
+            // check but lack a real console (some container runtimes,
+            // dotnet test capture, certain CI runners with tty: true but no
+            // /dev/tty wiring, restricted hosts, WSL + ssh -t edge cases).
+            // Fail closed: do NOT fall back to Console.ReadLine, which would
+            // echo the secret to scrollback / tmux logs / TTY loggers. Emit
+            // a one-line stderr warning and return null so the caller short-
+            // circuits to ExitCanceled (130) without ever accepting plaintext.
+            // Newman audit H-1.
+            Console.Error.WriteLine(
+                "[ERROR] Cannot read masked input on this terminal; refusing to "
+                + "accept API key in plaintext. Set AZUREOPENAIAPI environment "
+                + "variable instead.");
+            return null;
         }
     }
 }

--- a/azureopenai-cli/UserConfig.cs
+++ b/azureopenai-cli/UserConfig.cs
@@ -49,6 +49,21 @@ internal sealed class UserConfig
     public UserDefaults Defaults { get; set; } = new();
 
     /// <summary>
+    /// Azure OpenAI endpoint URL (written by the setup wizard). Used as a fallback
+    /// when the <c>AZUREOPENAIENDPOINT</c> environment variable is not set.
+    /// </summary>
+    [JsonPropertyName("endpoint")]
+    public string? Endpoint { get; set; }
+
+    /// <summary>
+    /// Azure OpenAI API key (written by the setup wizard). Used as a fallback
+    /// when the <c>AZUREOPENAIAPI</c> environment variable is not set. Stored
+    /// in a 0600-permissioned file; redacted by <see cref="ListKeys"/>.
+    /// </summary>
+    [JsonPropertyName("api_key")]
+    public string? ApiKey { get; set; }
+
+    /// <summary>
     /// Path this config was loaded from (null if no file found). Not serialized.
     /// </summary>
     [JsonIgnore]
@@ -169,6 +184,12 @@ internal sealed class UserConfig
             case "default_model":
                 DefaultModel = value;
                 return true;
+            case "endpoint":
+                Endpoint = value;
+                return true;
+            case "api_key":
+                ApiKey = value;
+                return true;
             case "models" when parts.Length == 2:
                 Models[parts[1]] = value;
                 return true;
@@ -187,6 +208,8 @@ internal sealed class UserConfig
         return parts[0] switch
         {
             "default_model" => DefaultModel,
+            "endpoint" => Endpoint,
+            "api_key" => ApiKey,
             "models" when parts.Length == 2 => Models.TryGetValue(parts[1], out var v) ? v : null,
             "defaults" when parts.Length == 2 => Defaults.GetKey(parts[1]),
             _ => null,
@@ -198,6 +221,10 @@ internal sealed class UserConfig
     {
         if (!string.IsNullOrEmpty(DefaultModel))
             yield return $"default_model={DefaultModel}";
+        if (!string.IsNullOrEmpty(Endpoint))
+            yield return $"endpoint={Endpoint}";
+        if (!string.IsNullOrEmpty(ApiKey))
+            yield return "api_key=<redacted>";
         foreach (var kv in Models.OrderBy(k => k.Key, StringComparer.Ordinal))
             yield return $"models.{kv.Key}={kv.Value}";
         foreach (var line in Defaults.ListKeys())

--- a/tests/AzureOpenAI_CLI.Tests/SetupAndBareSubcommandTests.cs
+++ b/tests/AzureOpenAI_CLI.Tests/SetupAndBareSubcommandTests.cs
@@ -107,7 +107,76 @@ public class SetupAndBareSubcommandTests
 
         var output = sw.ToString();
         Assert.Contains("--setup", output);
+        Assert.Contains("--init-wizard", output);
         Assert.Contains("az-ai help", output);
         Assert.Contains("az-ai setup", output);
+    }
+
+    // ── ShouldAutoLaunchSetup decision helper ─────────────────────────────
+    // Pure predicate (no Console / env reads): the caller passes terminal
+    // facts in. Tests cover both the positive path (bare az-ai with no
+    // creds on a TTY -> launch) and the four documented negative gates.
+
+    [Fact]
+    public void ShouldAutoLaunchSetup_BareInteractiveNoCreds_ReturnsTrue()
+    {
+        var opts = Program.ParseArgs([]);
+        Assert.True(Program.ShouldAutoLaunchSetup(
+            opts, endpoint: null, apiKey: null,
+            isInteractiveTty: true, stdinRedirected: false));
+    }
+
+    [Fact]
+    public void ShouldAutoLaunchSetup_CredsPresent_ReturnsFalse()
+    {
+        var opts = Program.ParseArgs([]);
+        Assert.False(Program.ShouldAutoLaunchSetup(
+            opts, endpoint: "https://example.openai.azure.com",
+            apiKey: "k",
+            isInteractiveTty: true, stdinRedirected: false));
+    }
+
+    [Fact]
+    public void ShouldAutoLaunchSetup_PromptGiven_ReturnsFalse()
+    {
+        // Bare prompt => user wants to chat, not configure. Fall through to
+        // the env-var error so they see why their unconfigured run failed.
+        var opts = Program.ParseArgs(["hello"]);
+        Assert.False(Program.ShouldAutoLaunchSetup(
+            opts, endpoint: null, apiKey: null,
+            isInteractiveTty: true, stdinRedirected: false));
+    }
+
+    [Fact]
+    public void ShouldAutoLaunchSetup_StdinRedirected_ReturnsFalse()
+    {
+        // Pipe / heredoc => caller is scripted; never block on a prompt.
+        var opts = Program.ParseArgs([]);
+        Assert.False(Program.ShouldAutoLaunchSetup(
+            opts, endpoint: null, apiKey: null,
+            isInteractiveTty: true, stdinRedirected: true));
+    }
+
+    [Fact]
+    public void ShouldAutoLaunchSetup_RawOrJson_ReturnsFalse()
+    {
+        var rawOpts = Program.ParseArgs(["--raw"]);
+        Assert.False(Program.ShouldAutoLaunchSetup(
+            rawOpts, endpoint: null, apiKey: null,
+            isInteractiveTty: true, stdinRedirected: false));
+
+        var jsonOpts = Program.ParseArgs(["--json"]);
+        Assert.False(Program.ShouldAutoLaunchSetup(
+            jsonOpts, endpoint: null, apiKey: null,
+            isInteractiveTty: true, stdinRedirected: false));
+    }
+
+    [Fact]
+    public void ShouldAutoLaunchSetup_NotInteractive_ReturnsFalse()
+    {
+        var opts = Program.ParseArgs([]);
+        Assert.False(Program.ShouldAutoLaunchSetup(
+            opts, endpoint: null, apiKey: null,
+            isInteractiveTty: false, stdinRedirected: false));
     }
 }

--- a/tests/AzureOpenAI_CLI.Tests/SetupWizardTests.cs
+++ b/tests/AzureOpenAI_CLI.Tests/SetupWizardTests.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using AzureOpenAI_CLI;
+
+namespace AzureOpenAI_CLI.V2.Tests;
+
+/// <summary>
+/// Tests for the first-run setup wizard: CLI flag plumbing, UserConfig
+/// round-trip of the new credential fields, and redaction of the API key
+/// in <see cref="UserConfig.ListKeys"/>.
+/// </summary>
+public class SetupWizardTests
+{
+    [Fact]
+    public void ParseArgs_SetupFlag_IsRecognized()
+    {
+        var opts = Program.ParseArgs(["--setup"]);
+
+        Assert.True(opts.Setup);
+        Assert.False(opts.ParseError);
+    }
+
+    [Fact]
+    public void ParseArgs_InitWizardAlias_IsRecognized()
+    {
+        var opts = Program.ParseArgs(["--init-wizard"]);
+
+        Assert.True(opts.Setup);
+        Assert.False(opts.ParseError);
+    }
+
+    [Fact]
+    public void ParseArgs_NoSetupFlag_DefaultsToFalse()
+    {
+        var opts = Program.ParseArgs([]);
+        Assert.False(opts.Setup);
+    }
+
+    [Fact]
+    public void UserConfig_EndpointAndApiKey_RoundTrip()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"az-ai-wizard-rt-{Guid.NewGuid():N}.json");
+        try
+        {
+            var cfg = new UserConfig
+            {
+                Endpoint = "https://example.openai.azure.com",
+                ApiKey = "sk-test-0123456789abcdef-0123456789abcdef",
+                DefaultModel = "default",
+            };
+            cfg.Models["default"] = "gpt-4o-mini";
+            cfg.Save(path);
+
+            var loaded = UserConfig.Load(path);
+
+            Assert.Equal("https://example.openai.azure.com", loaded.Endpoint);
+            Assert.Equal("sk-test-0123456789abcdef-0123456789abcdef", loaded.ApiKey);
+            Assert.Equal("default", loaded.DefaultModel);
+            Assert.Equal("gpt-4o-mini", loaded.Models["default"]);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void UserConfig_ListKeys_RedactsApiKey()
+    {
+        var cfg = new UserConfig
+        {
+            Endpoint = "https://example.openai.azure.com",
+            ApiKey = "this-should-never-appear-in-output",
+            DefaultModel = "default",
+        };
+        cfg.Models["default"] = "gpt-4o-mini";
+
+        var keys = cfg.ListKeys().ToList();
+
+        Assert.Contains("endpoint=https://example.openai.azure.com", keys);
+        Assert.Contains("api_key=<redacted>", keys);
+        Assert.DoesNotContain(keys, line => line.Contains("this-should-never-appear"));
+    }
+
+    [Fact]
+    public void UserConfig_SetKey_AcceptsEndpointAndApiKey()
+    {
+        var cfg = new UserConfig();
+
+        Assert.True(cfg.SetKey("endpoint", "https://example.openai.azure.com"));
+        Assert.True(cfg.SetKey("api_key", "abcd1234"));
+
+        Assert.Equal("https://example.openai.azure.com", cfg.Endpoint);
+        Assert.Equal("abcd1234", cfg.ApiKey);
+    }
+
+    [Fact]
+    public void UserConfig_GetKey_ReturnsEndpointAndApiKey()
+    {
+        var cfg = new UserConfig
+        {
+            Endpoint = "https://example.openai.azure.com",
+            ApiKey = "topsecret",
+        };
+
+        Assert.Equal("https://example.openai.azure.com", cfg.GetKey("endpoint"));
+        Assert.Equal("topsecret", cfg.GetKey("api_key"));
+    }
+}

--- a/tests/AzureOpenAI_CLI.Tests/SetupWizardTests.cs
+++ b/tests/AzureOpenAI_CLI.Tests/SetupWizardTests.cs
@@ -50,7 +50,7 @@ public class SetupWizardTests
             var cfg = new UserConfig
             {
                 Endpoint = "https://example.openai.azure.com",
-                ApiKey = "sk-test-0123456789abcdef-0123456789abcdef",
+                ApiKey = "api-key-test-0123456789abcdef0123456789abcdef",
                 DefaultModel = "default",
             };
             cfg.Models["default"] = "gpt-4o-mini";
@@ -59,7 +59,7 @@ public class SetupWizardTests
             var loaded = UserConfig.Load(path);
 
             Assert.Equal("https://example.openai.azure.com", loaded.Endpoint);
-            Assert.Equal("sk-test-0123456789abcdef-0123456789abcdef", loaded.ApiKey);
+            Assert.Equal("api-key-test-0123456789abcdef0123456789abcdef", loaded.ApiKey);
             Assert.Equal("default", loaded.DefaultModel);
             Assert.Equal("gpt-4o-mini", loaded.Models["default"]);
         }

--- a/tests/AzureOpenAI_CLI.Tests/SetupWizardTests.cs
+++ b/tests/AzureOpenAI_CLI.Tests/SetupWizardTests.cs
@@ -277,6 +277,37 @@ public class SetupWizardTests
         Assert.Contains("https://example.openai.azure.com", stdout.ToString());
     }
 
+    // ── PromptEndpoint URL validation ────────────────────────────────────
+    //
+    // TryParseEndpointUrl is internal so it can be exercised directly.
+    // These tests guard against a persisted misconfiguration that silently
+    // breaks the client SDK's URL construction at runtime.
+
+    [Theory]
+    [InlineData("https://my-resource.openai.azure.com")]
+    [InlineData("https://my-resource.openai.azure.com/")]
+    public void TryParseEndpointUrl_ValidRootUrl_ReturnsTrue(string url)
+    {
+        Assert.True(SetupWizard.TryParseEndpointUrl(url, out var rejection));
+        Assert.Null(rejection);
+    }
+
+    [Theory]
+    [InlineData("http://my-resource.openai.azure.com", "must start with https")]
+    [InlineData("my-resource.openai.azure.com", "must start with https")]
+    [InlineData("https://my-resource.openai.azure.com/openai/deployments", "no path")]
+    [InlineData("https://my-resource.openai.azure.com/openai", "no path")]
+    [InlineData("https://my-resource.openai.azure.com?api-version=2024-05-01", "no path, query, or fragment")]
+    [InlineData("https://my-resource.openai.azure.com/#section", "no path, query, or fragment")]
+    public void TryParseEndpointUrl_InvalidUrl_ReturnsFalseWithMessage(string url, string expectedFragment)
+    {
+        var ok = SetupWizard.TryParseEndpointUrl(url, out var rejection);
+
+        Assert.False(ok);
+        Assert.NotNull(rejection);
+        Assert.Contains(expectedFragment, rejection, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static string FindSourceFile(string leaf)
     {
         // Walk up from the test assembly location until we find the repo's

--- a/tests/AzureOpenAI_CLI.Tests/SetupWizardTests.cs
+++ b/tests/AzureOpenAI_CLI.Tests/SetupWizardTests.cs
@@ -7,7 +7,13 @@ namespace AzureOpenAI_CLI.V2.Tests;
 /// Tests for the first-run setup wizard: CLI flag plumbing, UserConfig
 /// round-trip of the new credential fields, and redaction of the API key
 /// in <see cref="UserConfig.ListKeys"/>.
+/// <para>
+/// Newman audit H-2 added Console-capturing tests to this class; the
+/// whole class joins the <c>ConsoleCapture</c> collection so capture
+/// can't interleave with other capturing suites.
+/// </para>
 /// </summary>
+[Collection("ConsoleCapture")]
 public class SetupWizardTests
 {
     [Fact]
@@ -104,5 +110,184 @@ public class SetupWizardTests
 
         Assert.Equal("https://example.openai.azure.com", cfg.GetKey("endpoint"));
         Assert.Equal("topsecret", cfg.GetKey("api_key"));
+    }
+
+    // ── Newman audit H-1: ReadMaskedLine fail-closed regression guard ────
+    //
+    // ReadMaskedLine's InvalidOperationException catch must NOT fall back
+    // to Console.ReadLine() — that would echo the secret in plaintext on
+    // pseudo-TTYs that pass the redirect check but lack a real console.
+    // Forcing the exception in xUnit is hard (we can't easily fake
+    // Console.ReadKey), so this is a static-analysis-style regression
+    // guard: read the source file and assert Console.ReadLine does NOT
+    // appear inside the body of ReadMaskedLine. Ugly, but it's a true
+    // regression guard.
+    [Fact]
+    public void SetupWizard_ReadMaskedLine_DoesNotFallBackToReadLine()
+    {
+        var sourcePath = FindSourceFile("SetupWizard.cs");
+        Assert.True(File.Exists(sourcePath), $"source file missing: {sourcePath}");
+        var src = File.ReadAllText(sourcePath);
+
+        // Locate the ReadMaskedLine method body.
+        var sigIdx = src.IndexOf("private static string? ReadMaskedLine()", StringComparison.Ordinal);
+        Assert.True(sigIdx > 0, "ReadMaskedLine signature not found in SetupWizard.cs");
+
+        // Find the opening brace, then walk the brace-depth to find the close.
+        var bodyStart = src.IndexOf('{', sigIdx);
+        Assert.True(bodyStart > 0, "ReadMaskedLine opening brace not found");
+        int depth = 0;
+        int bodyEnd = -1;
+        for (int i = bodyStart; i < src.Length; i++)
+        {
+            if (src[i] == '{') depth++;
+            else if (src[i] == '}') { depth--; if (depth == 0) { bodyEnd = i; break; } }
+        }
+        Assert.True(bodyEnd > bodyStart, "ReadMaskedLine closing brace not found");
+
+        var body = src.Substring(bodyStart, bodyEnd - bodyStart + 1);
+
+        // Strip // line comments before scanning — comments referencing
+        // the unmasked ReadLine API by name are fine (and useful), what
+        // we're guarding against is an actual call. We don't bother with
+        // /* */ block comments because the codebase doesn't use them in
+        // method bodies.
+        var stripped = System.Text.RegularExpressions.Regex.Replace(
+            body, @"//[^\r\n]*", string.Empty);
+        Assert.DoesNotContain("Console.ReadLine", stripped);
+
+        // And the failure path must emit a stderr warning + return null
+        // (the fail-closed contract). Anchor on the [ERROR] substring so a
+        // future copy-edit doesn't have to chase the full sentence.
+        Assert.Contains("Console.Error.WriteLine", body);
+        Assert.Contains("[ERROR]", body);
+    }
+
+    // ── Newman audit H-2: --config get api_key refuses to print ──────────
+    //
+    // Exercises Program.HandleConfigSubcommand with the parsed opts and a
+    // config that has an api_key set. Verifies the runtime path refuses
+    // (exit 1) and never prints the raw key to stdout. Mirrors the style
+    // of UserConfig_ListKeys_RedactsApiKey.
+    [Fact]
+    [Trait("Category", "ConsoleCapture")]
+    public void ConfigGet_ApiKey_RefusesAndDoesNotPrintSecret()
+    {
+        var opts = Program.ParseArgs(["--config", "get", "api_key"]);
+        Assert.Equal("get", opts.ConfigSubcommand);
+        Assert.Equal("api_key", opts.ConfigKey);
+        Assert.False(opts.ParseError);
+
+        var cfg = new UserConfig
+        {
+            Endpoint = "https://example.openai.azure.com",
+            ApiKey = "this-secret-must-never-appear-in-stdout",
+        };
+
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        var origOut = Console.Out;
+        var origErr = Console.Error;
+        int rc;
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            rc = Program.HandleConfigSubcommand(opts, cfg);
+        }
+        finally
+        {
+            Console.SetOut(origOut);
+            Console.SetError(origErr);
+        }
+
+        Assert.Equal(1, rc);
+        var outText = stdout.ToString();
+        var errText = stderr.ToString();
+
+        // Hard invariant: the secret never appears on stdout OR stderr.
+        Assert.DoesNotContain("this-secret-must-never-appear-in-stdout", outText);
+        Assert.DoesNotContain("this-secret-must-never-appear-in-stdout", errText);
+
+        // The refusal message lands on stderr (ErrorAndExit convention).
+        Assert.Contains("Refusing to print api_key", errText);
+        Assert.Contains("--setup", errText);
+    }
+
+    [Fact]
+    [Trait("Category", "ConsoleCapture")]
+    public void ConfigGet_ApiKey_JsonMode_RefusesWithStructuredError()
+    {
+        var opts = Program.ParseArgs(["--json", "--config", "get", "api_key"]);
+        Assert.True(opts.Json);
+
+        var cfg = new UserConfig
+        {
+            ApiKey = "this-secret-must-never-appear-in-stdout",
+        };
+
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+        var origOut = Console.Out;
+        var origErr = Console.Error;
+        int rc;
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            rc = Program.HandleConfigSubcommand(opts, cfg);
+        }
+        finally
+        {
+            Console.SetOut(origOut);
+            Console.SetError(origErr);
+        }
+
+        Assert.Equal(1, rc);
+        // Secret must not appear on either stream.
+        Assert.DoesNotContain("this-secret-must-never-appear-in-stdout", stdout.ToString());
+        Assert.DoesNotContain("this-secret-must-never-appear-in-stdout", stderr.ToString());
+        // JSON-mode errors go to stderr (ErrorAndExit convention) — happy-path
+        // stdout stays clean for `| jq` consumers.
+        Assert.Contains("\"error\"", stderr.ToString());
+    }
+
+    [Fact]
+    public void ConfigGet_NonSecretKey_StillReturnsValue()
+    {
+        // Sanity: redaction is api_key-specific, not blanket. endpoint and
+        // default_model still print as before.
+        var opts = Program.ParseArgs(["--config", "get", "endpoint"]);
+        var cfg = new UserConfig { Endpoint = "https://example.openai.azure.com" };
+
+        var stdout = new StringWriter();
+        var origOut = Console.Out;
+        int rc;
+        try
+        {
+            Console.SetOut(stdout);
+            rc = Program.HandleConfigSubcommand(opts, cfg);
+        }
+        finally
+        {
+            Console.SetOut(origOut);
+        }
+
+        Assert.Equal(0, rc);
+        Assert.Contains("https://example.openai.azure.com", stdout.ToString());
+    }
+
+    private static string FindSourceFile(string leaf)
+    {
+        // Walk up from the test assembly location until we find the repo's
+        // azureopenai-cli/ directory containing the requested file.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, "azureopenai-cli", leaf);
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return string.Empty;
     }
 }


### PR DESCRIPTION
## Summary

Reconciles parallel `--setup` wizard implementations (local stash + upstream PR #14) and closes two High-severity secret-disclosure surfaces flagged by Newman's audit.

Three commits on this branch:

| SHA | Commit |
|-----|--------|
| `85a59bf` | `fix(setup): reconcile parallel wizard implementations` |
| `8cfb9bf` | `feat(setup): auto-launch wizard on bare az-ai with no creds; document --init-wizard alias` |
| `c138c75` | `fix(security): close H-1 + H-2 secret-disclosure surfaces in wizard` |

Diff vs `main`: +751 / −124 across 6 files.

## Background

Local work-in-progress (preserved as `stash@{0}`, dated 2026-04-22) was independently building the same `--setup` wizard upstream just shipped in PR #14. The stash version had stronger security/UX invariants (TTY guard, masked `*` input, exit 130 on Ctrl+C, 0600 perms via `UserConfig.Save`); upstream had bare-subcommand parser work (`help` / `setup` literal-arg handling) and `SetupAndBareSubcommandTests.cs`. Neither version dominated the other — this branch combines both.

## What changed

### Commit 1 — `85a59bf`: reconcile

- Rewrote `SetupWizard.cs` (354 lines) with upstream's `RunAsync()` signature + stash's invariants:
  - `IsInteractiveTty()` guard (refuses redirected stdin/stdout)
  - Masked API-key input via `Console.ReadKey(intercept: true)`, `*` echo, Backspace + Esc + EOF handling
  - Success-only `UserConfig.Save` (no partial writes on Ctrl+C)
- `Program.cs` `--setup` branch refuses `--raw` / `--json` / non-TTY before invoking the wizard
- `UserConfig.cs` adds `Endpoint` / `ApiKey` JSON fields, `SetKey` / `GetKey` cases for `endpoint` / `api_key`, `ListKeys` redaction
- `SetupWizardTests.cs` ports stash's parser-flag + UserConfig round-trip + redaction tests (108 lines, no overlap with upstream's `SetupAndBareSubcommandTests.cs`)

### Commit 2 — `8cfb9bf`: auto-launch + alias docs

- Implemented bare-`az-ai`-with-no-creds wizard auto-trigger via pure `ShouldAutoLaunchSetup` predicate (6 unit tests, no PTY harness needed)
- Env → `UserConfig` credential fallback so persisted-config users don't get the wizard mis-fired
- Documented `--init-wizard` alias in `ShowHelp()`, embedded bash / zsh / fish completion strings
- Closed CHANGELOG-vs-code drift (the `[Unreleased]` entry already promised this behavior)

### Commit 3 — `c138c75`: H-1 + H-2 hardening

Closes Newman's two High-severity findings:

- **H-1**: `ReadMaskedLine` no longer falls back to unmasked `Console.ReadLine` when `ReadKey` throws on broken pseudo-TTYs (containers, certain CI runners, WSL+ssh edge cases). Now fails closed with stderr warning + exit 130. Static-analysis regression test guards against future "let's just gracefully fall back" patches.
- **H-2**: `--config get api_key` now refuses with a helpful message instead of printing the raw key to stdout. JSON-mode-aware via `ErrorAndExit`. `UserConfig.GetKey("api_key")` itself still returns the raw value for in-process callers (the wizard needs it); the fix lives at the print site.

## Test impact

- **Unit tests**: 581 passing (was 567 on `main`, +14 new)
- **Integration tests**: 34 passing, 2 skipped (require live Azure creds)
- **Preflight**: green at every commit (format, color-contract-lint, build, unit, integration)

## Backlog (deferred to separate PRs)

Newman's Medium findings — none of these block this PR:

- **M-1**: TOCTOU window between `File.WriteAllText` and `SetUnixFileMode` in `UserConfig.Save` (atomic-rename pattern needed)
- **M-2**: SSRF / private-IP warning at endpoint config time (share helper with `WebFetchTool` allowlist)
- **M-3**: Windows DACL not enforced on persisted JSON
- **M-5**: 16-char API key min-length is a soft floor that could reject future Azure key formats
- (M-4 was subsumed by H-1 fix.)

## Reviewers

- **Newman**: H-1 / H-2 closure verification (audit was on `85a59bf`; commit 3 closes both findings)
- **Mr. Lippman**: CHANGELOG `[Unreleased]` entries are now consistent with shipped behavior
- **Bob Sacamano**: completion scripts now expose `--init-wizard`; Homebrew / Scoop / Nix consumers regenerating completions pick it up automatically
- **Elaine** *(post-merge)*: `man/az-ai.1` predates the wizard entirely — separate PR to add the Setup section

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
